### PR TITLE
Added www to neon url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -52,7 +52,7 @@ links:
     url: /cheatsheets/
     
   - title: NEON Website
-    url: http://neoninc.org
+    url: http://www.neoninc.org
     external: true
 
 # http://en.wikipedia.org/wiki/List_of_tz_database_time_zones


### PR DESCRIPTION
Link doesn't always work without www.
